### PR TITLE
"#5 Add CI/CD baseline & branch protection"

### DIFF
--- a/.github/Workflows/Ci.yml
+++ b/.github/Workflows/Ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm -r test
+
+      - name: Build
+        run: pnpm -r build

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # root package.json
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"    

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,3 +27,10 @@
 - Added dev dependencies: `tsx`, `typescript`, `vitest`, `supertest`.  
 - Verified API dev server on `localhost:4000` with `/health` route.  
 - Confirmed monorepo root tooling (lint, format, test) applies cleanly across apps.  
+
+## [0.0.5] - 2025-08-21 - "#5 Add CI/CD baseline & branch protection"
+
+- Added GitHub Actions workflow for monorepo: install deps, lint, test, build web & api.
+- Enabled branch protection on main (PR + passing checks required).
+- Added CI status badge to README.md.
+- Enabled Dependabot for npm updates.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/AJDStudios/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/AJDStudios/portfolio/actions/workflows/ci.yml)
+
 # Aaron’s Portfolio (v2)
 
 This repo is the home of my new developer portfolio site.  


### PR DESCRIPTION
- Added GitHub Actions workflow for monorepo: install deps, lint, test, build web & api.
- Enabled branch protection on main (PR + passing checks required). - already completed in init
- Added CI status badge to README.md.
- Enabled Dependabot for npm updates.