### PR TITLE
Repo hygiene: templates, policies, and planning docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,30 @@
+---
+name: "🐞 Bug report"
+about: Report a problem
+labels: bug
+---
+
+### Summary
+<!-- What happened? -->
+
+### Steps to Reproduce
+1.
+2.
+3.
+
+### Expected vs Actual
+**Expected:**
+**Actual:**
+
+### Screenshots / Logs
+<!-- Attach images or paste logs if helpful -->
+
+### Environment
+- OS:
+- Browser/Node:
+- Version/Commit:
+
+### Checklist
+- [ ] I’ve searched existing issues
+- [ ] I can reproduce on main
+- [ ] Added minimal repro steps above

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,0 +1,22 @@
+---
+name: "✨ Feature request"
+about: Propose a new capability
+labels: enhancement
+---
+
+### Problem / User Story
+<!-- What user pain or outcome are we solving? -->
+
+### Proposal
+<!-- What do you want to build? -->
+
+### Scope (In / Out)
+- **In:**
+- **Out:**
+
+### Acceptance Criteria
+- [ ] …
+- [ ] …
+
+### Risks / Open Questions
+- …

--- a/.github/ISSUE_TEMPLATE/Task.md
+++ b/.github/ISSUE_TEMPLATE/Task.md
@@ -1,0 +1,14 @@
+---
+name: "🧩 Task"
+about: Small scoped task or chore
+labels: task
+---
+
+### Goal
+<!-- What needs doing? -->
+
+### Definition of Done
+- [ ] …
+
+### Notes
+<!-- Links, context, refs -->

--- a/.github/Pull_Request_Template.md
+++ b/.github/Pull_Request_Template.md
@@ -1,0 +1,21 @@
+## What’s in this PR
+<!-- Short summary -->
+
+## Why
+<!-- User value / problem statement -->
+
+## Changes
+- …
+
+## Screenshots / UI
+<!-- Before/after if UI -->
+
+## Checklist
+- [ ] Tests pass locally (`pnpm -r test`)
+- [ ] Lint/format pass (`pnpm lint` / `pnpm format --check`)
+- [ ] A11y considered (labels, focus states, color contrast)
+- [ ] Docs updated (CHANGELOG, if user-facing)
+- [ ] No secrets committed
+
+## Linked issues
+Closes #NNN

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,3 +34,13 @@
 - Enabled branch protection on main (PR + passing checks required).
 - Added CI status badge to README.md.
 - Enabled Dependabot for npm updates.
+
+## [0.0.6] - 2025-08-22 - "#6 Repo polish & templates"
+
+- Added issue templates: `bug.md`, `feature.md`, `task.md`.  
+- Added PR template with checklist (tests, a11y, screenshots if UI).  
+- Added `SECURITY.md` and `PRIVACY.md` (linked from README).  
+- Created GitHub Project board (Backlog → In Progress → Review → Done).  
+- Updated `PROJECT_PLAN.md` with Phase 1–3 bullets and cadence.  
+- Updated `README.md` with week 1 status and links.  
+- **Note:** This repo will also be cloned and saved as a reusable project template.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,26 @@
+# Privacy Policy (Portfolio)
+
+## What data this site collects
+- Optional survey responses (non-PII by design)
+- Aggregated analytics (page views, performance metrics)
+- Contact form submissions (if enabled): name, email, message
+
+## What we **do not** collect
+- No passwords, payment data, or sensitive categories
+- No precise location
+
+## Purpose
+- Demonstrate data handling and querying
+- Improve site UX and performance
+
+## Retention
+- Survey data kept for demo until manually cleared
+- Contact submissions retained only to respond, then deleted on request
+
+## Third parties
+- None by default. If enabled (e.g., Sentry/analytics), providers will be listed here with links to their policies.
+
+## Your rights
+- Request deletion of your submissions: open an issue or email the address in `SECURITY.md`.
+
+_Last updated: 2025-08-22_

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -3,18 +3,21 @@
 ## Vision
 
 Show senior-level practice through a lean site: accessible UI, data handling,
-and transparent repo process (issues, changelog, releases).
+and transparent repo process (issues, changelog, releases). Treat this repo as
+a reusable template baseline for future projects.
 
 ## Phases (high-level)
 
-1. Foundations: repo, CI, envs, a11y baseline
-2. Core site skeleton: routes, tokens, content placeholders
-3. Data feature: 5 Qs + SQL demo explorer
-4. Mini-projects: 2 inline demos (MVP), 3rd later
-5. Polish: docs, a11y/Lighthouse, easter eggs
+1. **Foundations**: repo, CI, envs, a11y baseline, secrets hygiene [x]
+2. **Core site skeleton**: routes, tokens, content []
+3. **Data feature**: 5 Qs + SQL demo explorer []
+4. **Mini-projects**: 2 inline demos (MVP), 3rd later []
+5. **Polish**: docs, a11y/Lighthouse, easter eggs []
 
 ## Working cadence
 
-- ~5 issues/week (1 per weekday)
-- CHANGELOG entries per milestone
-- Protected `main`, PRs only
+* \~5 issues/week (1 per weekday)
+* **CHANGELOG and docs updated after each 5-issue sprint** (including README and PLAN)
+* Protected `main`, PRs only; CI (lint, tests, build) required to merge
+* Project board used for visibility: Backlog → In Progress → Review → Done
+* Templates (issues, PRs) and SECURITY/PRIVACY policies baked in from week 1

--- a/README.md
+++ b/README.md
@@ -3,21 +3,29 @@
 # Aaron’s Portfolio (v2)
 
 This repo is the home of my new developer portfolio site.  
-The goal is not just to showcase projects, but to demonstrate product thinking, data handling, and end-to-end engineering practice.
+The goal is not just to showcase projects, but to demonstrate **product thinking, data handling, and end-to-end engineering practice** — from initial planning to production-ready features.
 
 ### Current Status
 
-- **Day 0**: Repository created. Planning phase underway.
-- See [PROJECT_PLAN.md](./PROJECT_PLAN.md) for roadmap and tickets.
+- **Week 1 (Issues #1–6)**: Foundations in place: repo scaffold, CI, Postgres via Docker, initial web/app setup, templates, and policies.
+- See [PROJECT_PLAN.md](./PROJECT_PLAN.md) for roadmap and cadence.
+- See [CHANGELOG.md](./CHANGELOG.md) for milestone history.
 
 ### Key Features (Planned)
 
-- Clean React/Node/Django stack
+- Clean React (Vite) + Node stack
 - Interactive About + Skills (mini-projects)
 - Data collection section with playful prompts
-- SQL demo + visualization
+- SQL demo + visualization (pgAdmin-ready)
 - Accessible-first design (Lighthouse tested)
+- GitHub Actions CI/CD, Dependabot, branch protection
 - Easter eggs for devs
+
+### Contributing & Policies
+
+- Issue and PR templates live under `.github/`
+- SECURITY and PRIVACY policies included; no secrets committed
+- Project board visible [here](link to board)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+This is a personal portfolio project; security fixes are handled on a best-effort basis.
+
+## Reporting a Vulnerability
+Please open a **Security Advisory** (GitHub → Security → Advisories) or email:
+`` (or use GitHub private report).
+
+Include:
+- Steps to reproduce
+- Impact assessment (data exposure, RCE, etc.)
+- Any PoC
+
+We will acknowledge within 7 days and coordinate a fix + credit.


### PR DESCRIPTION
## [0.0.6] - 2025-08-22 - "#6 Repo polish & templates"

- Added issue templates: `bug.md`, `feature.md`, `task.md`.  
- Added PR template with checklist (tests, a11y, screenshots if UI).  
- Added `SECURITY.md` and `PRIVACY.md` (linked from README).  
- Created GitHub Project board (Backlog → In Progress → Review → Done).  
- Updated `PROJECT_PLAN.md` with Phase 1–3 bullets and cadence.  
- Updated `README.md` with week 1 status and links.  
- **Note:** This repo will also be cloned and saved as a reusable project template.
